### PR TITLE
unify config access across all QA modules using Utils helpers

### DIFF
--- a/locales/zh_CN.po
+++ b/locales/zh_CN.po
@@ -496,6 +496,15 @@ msgstr "添加底部栏按钮"
 msgid "Cover Visual Settings"
 msgstr "封面视觉设置"
 
+msgid "QuickUI_InterfaceFilter"
+msgstr "QuickUI-界面过滤"
+
+msgid "QuickUI_Cover All/Uncover All"
+msgstr "QuickUI- 全部遮盖/全部揭开"
+
+msgid "QuickUI_SystemIconOverride"
+msgstr "QuickUI- 系统图标替换"
+
 msgid "Toggle Cloze Mode"
 msgstr "切换遮盖模式"
 
@@ -516,9 +525,6 @@ msgstr "QuickUI-页眉页脚设置"
 
 msgid "toggle_cloze_mode"
 msgstr "切换遮盖模式"
-
-msgid "QuickUI_ClozeSettings"
-msgstr "QuickUI-遮盖模式设置"
 
 msgid "No recent book found"
 msgstr "未找到最近阅读的书籍"
@@ -1479,9 +1485,6 @@ msgstr "QuickUI-启用遮盖模式"
 
 msgid "QuickUI_ClozeToggleAll"
 msgstr "QuickUI-切换全部填空"
-
-msgid "QuickUI_ClozeSettings"
-msgstr "QuickUI-遮盖模式设置"
 
 msgid "QuickUI_HFSettings"
 msgstr "QuickUI-页眉页脚设置"

--- a/qui_actions/qa_actions.lua
+++ b/qui_actions/qa_actions.lua
@@ -52,98 +52,6 @@ local ACTION_ORDER = {}
 local _wifi_optimistic = nil
 
 -- ============================================================
--- Configuration - Read from _G.__QUICKUI_CONFIG
--- ============================================================
-
-local function getBool(key)
-    local config = _G.__QUICKUI_CONFIG
-    if config and config[key] ~= nil then
-        return config[key] == true
-    end
-    return false
-end
-
-local function getString(key)
-    local config = _G.__QUICKUI_CONFIG
-    if config and config[key] ~= nil then
-        return config[key]
-    end
-    return ""
-end
-
-local function getTable(key)
-    local config = _G.__QUICKUI_CONFIG
-    if config and config[key] ~= nil then
-        return config[key]
-    end
-    return {}
-end
-
-local function getCustom()
-    local config = _G.__QUICKUI_CONFIG
-    if config and config.qa_common_custom then
-        return config.qa_common_custom
-    end
-    return {}
-end
-
-local function setCustom(value)
-    local config = _G.__QUICKUI_CONFIG
-    if config then
-        config.qa_common_custom = value
-        Utils.saveConfig()
-    end
-end
-
-local function getBuiltinOverrides()
-    local config = _G.__QUICKUI_CONFIG
-    if config and config.qa_common_builtin_overrides then
-        return config.qa_common_builtin_overrides
-    end
-    return {}
-end
-
-local function setBuiltinOverrides(value)
-    local config = _G.__QUICKUI_CONFIG
-    if config then
-        config.qa_common_builtin_overrides = value
-        Utils.saveConfig()
-    end
-end
-
-local function getQASlots()
-    local config = _G.__QUICKUI_CONFIG
-    if config and config.qa_panel_slots then
-        return config.qa_panel_slots
-    end
-    return {}
-end
-
-local function saveQASlots(slots)
-    local config = _G.__QUICKUI_CONFIG
-    if config then
-        config.qa_panel_slots = slots
-        Utils.saveConfig()
-    end
-end
-
-local function getCustomList()
-    local config = _G.__QUICKUI_CONFIG
-    if config and config.qa_common_custom_list then
-        return config.qa_common_custom_list
-    end
-    return {}
-end
-
-local function setCustomList(value)
-    local config = _G.__QUICKUI_CONFIG
-    if config then
-        config.qa_common_custom_list = value
-        Utils.saveConfig()
-    end
-end
-
--- ============================================================
 -- Network Manager Helper
 -- ============================================================
 
@@ -209,7 +117,7 @@ QA.getDefaultViewForActionType = getDefaultViewForActionType
 -- ============================================================
 
 function QA.getAction(id)
-    local builtin_overrides = getBuiltinOverrides()
+    local builtin_overrides = Utils.getTable("qa_common_builtin_overrides")
     if builtin_overrides[id] then
         return {
             label = builtin_overrides[id].label or (ACTION_REGISTRY[id] and ACTION_REGISTRY[id].label) or id,
@@ -231,7 +139,7 @@ function QA.getAction(id)
         }
     end
 
-    local custom = getCustom()
+    local custom = Utils.getTable("qa_common_custom")
     local cfg = custom[id]
     if type(cfg) == "table" and cfg.label then
         local view = cfg.view
@@ -427,7 +335,7 @@ function QA.isInPlace(id)
 end
 
 function QA.getLabelForAction(id)
-    local builtin_overrides = getBuiltinOverrides()
+    local builtin_overrides = Utils.getTable("qa_common_builtin_overrides")
     if builtin_overrides[id] and builtin_overrides[id].label then
         return builtin_overrides[id].label
     end
@@ -487,11 +395,11 @@ end
 
 function QA.getActionViewFinal(id)
     if not id then return "common" end
-    local overrides = getBuiltinOverrides()
+    local overrides = Utils.getTable("qa_common_builtin_overrides")
     if overrides and overrides[id] and overrides[id].view then
         return overrides[id].view
     end
-    local custom = getCustom()
+    local custom = Utils.getTable("qa_common_custom")
     local cfg = custom and custom[id]
     if cfg then
         if cfg.action_type == "menu" and cfg.menu_path and cfg.menu_path.view then
@@ -508,7 +416,7 @@ function QA.getActionViewFinal(id)
 end
 
 function QA.getTypePriority(id)
-    local cfg = getCustom()[id]
+    local cfg = Utils.getTable("qa_common_custom")[id]
     if cfg then
         if cfg.action_type == "menu" then
             return 1
@@ -550,7 +458,7 @@ function QA.getActionSymbol(id)
         return circle_char .. " "
     end
 
-    local cfg = getCustom()[id]
+    local cfg = Utils.getTable("qa_common_custom")[id]
     if cfg then
         if cfg.action_type == "dispatcher" then
             return "⊕ "
@@ -588,11 +496,11 @@ function QA.getAllAvailableActions()
             end
         end
     end
-    local custom_list = getCustomList()
+    local custom_list = Utils.getTable("qa_common_custom_list")
     if type(custom_list) == "table" then
         for i = 1, #custom_list do
             local id = custom_list[i]
-            local cfg = getCustom()[id]
+            local cfg = Utils.getTable("qa_common_custom")[id]
             if cfg then
                 local view = cfg.view
                 if not view then
@@ -615,7 +523,7 @@ function QA.getAllAvailableActions()
 end
 
 function QA.isActionVisible(action_id, current_view)
-    if not getBool("qa_common_context_filter") then return true end
+    if not Utils.getBool("qa_common_context_filter") then return true end
     local view = QA.getActionViewFinal(action_id)
     if current_view == "filemanager" then
         return view == "filemanager" or view == "common"
@@ -638,14 +546,14 @@ function QA.toggleDedicated(action_id, target_view)
                 _G.__QUICKUI_CONFIG.qa_common_builtin_overrides[action_id] = {}
             end
             _G.__QUICKUI_CONFIG.qa_common_builtin_overrides[action_id].view = "common"
-            setBuiltinOverrides(_G.__QUICKUI_CONFIG.qa_common_builtin_overrides)
+            Utils.set("qa_common_builtin_overrides", _G.__QUICKUI_CONFIG.qa_common_builtin_overrides)
         else
             if not _G.__QUICKUI_CONFIG.qa_common_custom then
                 _G.__QUICKUI_CONFIG.qa_common_custom = {}
             end
             if _G.__QUICKUI_CONFIG.qa_common_custom[action_id] then
                 _G.__QUICKUI_CONFIG.qa_common_custom[action_id].view = "common"
-                setCustom(_G.__QUICKUI_CONFIG.qa_common_custom)
+                Utils.set("qa_common_custom", _G.__QUICKUI_CONFIG.qa_common_custom)
             end
         end
     else
@@ -657,14 +565,14 @@ function QA.toggleDedicated(action_id, target_view)
                 _G.__QUICKUI_CONFIG.qa_common_builtin_overrides[action_id] = {}
             end
             _G.__QUICKUI_CONFIG.qa_common_builtin_overrides[action_id].view = target_view
-            setBuiltinOverrides(_G.__QUICKUI_CONFIG.qa_common_builtin_overrides)
+            Utils.set("qa_common_builtin_overrides", _G.__QUICKUI_CONFIG.qa_common_builtin_overrides)
         else
             if not _G.__QUICKUI_CONFIG.qa_common_custom then
                 _G.__QUICKUI_CONFIG.qa_common_custom = {}
             end
             if _G.__QUICKUI_CONFIG.qa_common_custom[action_id] then
                 _G.__QUICKUI_CONFIG.qa_common_custom[action_id].view = target_view
-                setCustom(_G.__QUICKUI_CONFIG.qa_common_custom)
+                Utils.set("qa_common_custom", _G.__QUICKUI_CONFIG.qa_common_custom)
             end
         end
     end
@@ -686,7 +594,7 @@ end
 -- ============================================================
 
 function QA.removeFromPanel(action_id, touch_menu)
-    local slots = getQASlots()
+    local slots = Utils.getTable("qa_panel_slots")
     local found = false
     local new_slots = {}
     for __, sid in ipairs(slots) do

--- a/qui_actions/qa_bottombar.lua
+++ b/qui_actions/qa_bottombar.lua
@@ -40,50 +40,6 @@ local M = {}
 M._add_tab_dialog = nil
 
 -- ============================================================
--- Configuration - Read from _G.__QUICKUI_CONFIG
--- ============================================================
-
-local function get(key, default)
-    local config = _G.__QUICKUI_CONFIG
-    if config and config[key] ~= nil then
-        return config[key]
-    end
-    return default
-end
-
-local function getBool(key, default)
-    local config = _G.__QUICKUI_CONFIG
-    if config and config[key] ~= nil then
-        return config[key] == true
-    end
-    return default or false
-end
-
-local function getString(key, default)
-    local config = _G.__QUICKUI_CONFIG
-    if config and config[key] ~= nil then
-        return config[key]
-    end
-    return default or ""
-end
-
-local function getNumber(key, default)
-    local config = _G.__QUICKUI_CONFIG
-    if config and config[key] ~= nil then
-        return config[key]
-    end
-    return default or 0
-end
-
-local function set(key, value)
-    local config = _G.__QUICKUI_CONFIG
-    if config then
-        config[key] = value
-        Utils.saveConfig()
-    end
-end
-
--- ============================================================
 -- Constants
 -- ============================================================
 
@@ -94,7 +50,7 @@ local MAX_TABS = 16
 -- ============================================================
 
 local function getNavbarScale()
-    return (getNumber("qa_bb_size_pct", 100) or 100) / 100
+    return (Utils.getNumber("qa_bb_size_pct", 100) or 100) / 100
 end
 
 function M.BAR_H()
@@ -102,12 +58,12 @@ function M.BAR_H()
 end
 
 function M.ICON_SZ()
-    local icon_scale = (getNumber("qa_bb_icon_scale_pct", 100) or 100) / 100
+    local icon_scale = (Utils.getNumber("qa_bb_icon_scale_pct", 100) or 100) / 100
     return math.floor(Screen:scaleBySize(19) * getNavbarScale() * icon_scale)
 end
 
 function M.LABEL_FS()
-    local label_scale = (getNumber("qa_bb_label_scale_pct", 100) or 100) / 100
+    local label_scale = (Utils.getNumber("qa_bb_label_scale_pct", 100) or 100) / 100
     return math.floor(12 * getNavbarScale() * label_scale)
 end
 
@@ -120,7 +76,7 @@ function M.TOP_SP()
 end
 
 function M.BOT_SP()
-    local margin = (getNumber("qa_bb_bottom_margin_pct", 100) or 100) / 100
+    local margin = (Utils.getNumber("qa_bb_bottom_margin_pct", 100) or 100) / 100
     return math.floor(Screen:scaleBySize(1) * margin)
 end
 
@@ -129,12 +85,12 @@ function M.SIDE_M()
 end
 
 function M.SEP_H()
-    if getString("qa_bb_style") == "framed" then return 0 end
+    if Utils.getString("qa_bb_style") == "framed" then return 0 end
     return Screen:scaleBySize(1)
 end
 
 function M.TOTAL_H()
-    if not getBool("qa_bb_enabled", true) then return 0 end
+    if not Utils.getBool("qa_bb_enabled", true) then return 0 end
     return M.BAR_H() + M.TOP_SP() + M.BOT_SP()
 end
 
@@ -143,8 +99,8 @@ end
 -- ============================================================
 
 local function getBarBg()
-    if getBool("qa_bb_transparent", false) then return nil end
-    local hex = getString("qa_bb_bg_color", "")
+    if Utils.getBool("qa_bb_transparent", false) then return nil end
+    local hex = Utils.getString("qa_bb_bg_color", "")
     if hex ~= "" then
         local c = Utils.hexToColor(hex)
         if c then return c end
@@ -153,7 +109,7 @@ local function getBarBg()
 end
 
 local function getBarFg()
-    local hex = getString("qa_bb_fg_color", "")
+    local hex = Utils.getString("qa_bb_fg_color", "")
     if hex ~= "" then
         local c = Utils.hexToColor(hex)
         if c then return c end
@@ -162,7 +118,7 @@ local function getBarFg()
 end
 
 local function getInactiveColor()
-    local hex = getString("qa_bb_inactive_color", "")
+    local hex = Utils.getString("qa_bb_inactive_color", "")
     if hex ~= "" then
         local c = Utils.hexToColor(hex)
         if c then return c end
@@ -171,7 +127,7 @@ local function getInactiveColor()
 end
 
 local function getAccentColor()
-    local hex = getString("qa_bb_accent_color", "")
+    local hex = Utils.getString("qa_bb_accent_color", "")
     if hex ~= "" then
         local c = Utils.hexToColor(hex)
         if c then return c end
@@ -247,8 +203,8 @@ function M.buildTabCell(action_id, active, tab_w, mode)
     local icon_path = QA.getIconForAction(action_id)
     local vg = VerticalGroup:new{ align = "center" }
     local fg = active and getAccentColor() or getBarFg()
-    local bar_style = getString("qa_bb_style", "default")
-    local show_labels = getBool("qa_bb_labels", false)
+    local bar_style = Utils.getString("qa_bb_style", "default")
+    local show_labels = Utils.getBool("qa_bb_labels", false)
 
     if mode == "icons" or mode == "both" then
         local icon_widget = makeIconWidget(icon_path, M.ICON_SZ(), fg)
@@ -296,7 +252,7 @@ function M.buildTabCell(action_id, active, tab_w, mode)
         content,
     }
 
-    if bar_style == "default" and not getBool("qa_bb_transparent", false) then
+    if bar_style == "default" and not Utils.getBool("qa_bb_transparent", false) then
         if active then
             og[#og + 1] = LineWidget:new{
                 dimen = Geom:new{ w = tab_w, h = M.INDIC_H() },
@@ -335,7 +291,7 @@ end
 -- ============================================================
 
 local function buildContainer(hg_args)
-    local style = getString("qa_bb_style", "default")
+    local style = Utils.getString("qa_bb_style", "default")
     local bg = getBarBg()
 
     if style == "framed" then
@@ -415,7 +371,7 @@ end
 function M.buildBar(active_action_id)
     local tabs = getTabs()
     local num_tabs = #tabs
-    local mode = getString("qa_bb_mode", "both")
+    local mode = Utils.getString("qa_bb_mode", "both")
     local screen_w = Screen:getWidth()
     local side_m = M.SIDE_M()
     local usable_w = screen_w - side_m * 2
@@ -450,9 +406,9 @@ function getAvailableActions()
 end
 
 function getTabs()
-    local tabs = get("qa_bb_tabs", nil)
+    local tabs = Utils.get("qa_bb_tabs", nil)
 
-    local filter_enabled = getBool("qa_common_context_filter")
+    local filter_enabled = Utils.getBool("qa_common_context_filter")
 
     local current_view = "common"
     if filter_enabled then
@@ -508,11 +464,11 @@ function getTabs()
 end
 
 function M.isEnabled()
-    return getBool("qa_bb_enabled", true)
+    return Utils.getBool("qa_bb_enabled", true)
 end
 
 function M.setEnabled(enabled)
-    set("qa_bb_enabled", enabled)
+    Utils.set("qa_bb_enabled", enabled)
 end
 
 -- ============================================================
@@ -593,7 +549,7 @@ function M.registerTouchZones(fm_self)
                 ratio_h = nav_h / screen_h,
             },
             handler = function()
-                if not getBool("qa_bb_button_hold_edit", true) then
+                if not Utils.getBool("qa_bb_button_hold_edit", true) then
                     return true
                 end
                 local action_id = tabs[pos]
@@ -635,7 +591,7 @@ function M.registerTouchZones(fm_self)
             ratio_h = nav_h / screen_h,
         },
         handler = function()
-            if getBool("qa_bb_settings_on_hold", true) then
+            if Utils.getBool("qa_bb_settings_on_hold", true) then
                 local settings = require("qui_actions.qa_settings")
                 if settings and settings.showBottombarSettings then
                     settings.showBottombarSettings()
@@ -655,7 +611,7 @@ end
 -- ============================================================
 
 function M.wrapWithBottombar(inner_widget)
-    if not getBool("qa_bb_enabled", true) then return inner_widget end
+    if not Utils.getBool("qa_bb_enabled", true) then return inner_widget end
 
     local screen_w = Screen:getWidth()
     local screen_h = Screen:getHeight()
@@ -731,8 +687,8 @@ function M.wrapWithBottombar(inner_widget)
     og._bottombar_bar_idx = 2
     og._bottombar_container = og
 
-    local is_bare = getString("qa_bb_style") == "bare"
-    local bg = (getBool("qa_bb_transparent", false) or is_bare) and nil or Blitbuffer.COLOR_WHITE
+    local is_bare = Utils.getString("qa_bb_style") == "bare"
+    local bg = (Utils.getBool("qa_bb_transparent", false) or is_bare) and nil or Blitbuffer.COLOR_WHITE
 
     return FrameContainer:new{
         bordersize = 0,
@@ -870,7 +826,7 @@ end
 -- ============================================================
 
 function M.showAddTabMenu(on_back, filtered_actions)
-    local current_tabs = get("qa_bb_tabs", nil)
+    local current_tabs = Utils.get("qa_bb_tabs", nil)
     if type(current_tabs) ~= "table" then
         current_tabs = {}
     end
@@ -997,7 +953,7 @@ function M.showAddTabMenu(on_back, filtered_actions)
                     end
                 end
 
-                set("qa_bb_tabs", new_tabs)
+                Utils.set("qa_bb_tabs", new_tabs)
                 M.refresh()
                 if M._add_tab_dialog then
                     UIManager:close(M._add_tab_dialog)
@@ -1043,7 +999,7 @@ function M.showAddTabMenu(on_back, filtered_actions)
                         new_tabs[#new_tabs + 1] = action.id
                     end
 
-                    set("qa_bb_tabs", new_tabs)
+                    Utils.set("qa_bb_tabs", new_tabs)
                     M.refresh()
                     if M._add_tab_dialog then
                         UIManager:close(M._add_tab_dialog)

--- a/qui_actions/qa_icon_picker.lua
+++ b/qui_actions/qa_icon_picker.lua
@@ -65,30 +65,10 @@ local THUMB_GAP = Screen:scaleBySize(6)
 -- Configuration 
 -- ============================================================
 
-function QA.init(plugin_ref)
-    logger.info("QuickUI QA IconPicker: initialized")
-end
-
-local function getTable(key)
-    local config = _G.__QUICKUI_CONFIG
-    if config and config[key] ~= nil then
-        return config[key]
-    end
-    return {}
-end
-
-local function setTable(key, value)
-    local config = _G.__QUICKUI_CONFIG
-    if config then
-        config[key] = value
-        Utils.saveConfig()
-    end
-end
-
 local function getSystemTempOverrides()
     if system_temp_overrides == nil then
         system_temp_overrides = {}
-        local saved = getTable("qa_common_icon_overrides")
+        local saved = Utils.getTable("qa_common_icon_overrides")
         for k, v in pairs(saved) do
             system_temp_overrides[k] = v
         end
@@ -1026,7 +1006,7 @@ function QA.showIconPicker(on_select, saved_icon, filter, mode, parent_mode)
     -- Build button row
     local btn_row
     if mode == "system" then
-        local all_overrides = getTable("qa_common_icon_overrides")
+        local all_overrides = Utils.getTable("qa_common_icon_overrides")
         local replaced = 0
         for _, item in ipairs(icons_list) do
             if temp_overrides[item.name] then
@@ -1047,7 +1027,7 @@ function QA.showIconPicker(on_select, saved_icon, filter, mode, parent_mode)
                     return
                 end
                 resetSystemTempOverrides()
-                setTable("qa_common_icon_overrides", {})
+                Utils.set("qa_common_icon_overrides", {})
                 picker_cache = {}
                 UIManager:show(Notification:new{
                     text = _("All icons reset, restart required"),
@@ -1076,7 +1056,7 @@ function QA.showIconPicker(on_select, saved_icon, filter, mode, parent_mode)
                     })
                     return
                 end
-                local overrides = getTable("qa_common_icon_overrides")
+                local overrides = Utils.getTable("qa_common_icon_overrides")
                 for k, _ in pairs(overrides) do
                     overrides[k] = nil
                 end
@@ -1085,7 +1065,7 @@ function QA.showIconPicker(on_select, saved_icon, filter, mode, parent_mode)
                         overrides[k] = v
                     end
                 end
-                setTable("qa_common_icon_overrides", overrides)
+                Utils.set("qa_common_icon_overrides", overrides)
                 resetSystemTempOverrides()
                 picker_cache = {}
                 UIManager:show(Notification:new{
@@ -1242,7 +1222,7 @@ function QA.showIconPicker(on_select, saved_icon, filter, mode, parent_mode)
                             local btn_width_sys = math.floor(content_w / 2) - 4
                             local btn_x_start = frame_x + pad
                             if gx >= btn_x_start and gx < btn_x_start + btn_width_sys then
-                                local all_overrides = getTable("qa_common_icon_overrides")
+                                local all_overrides = Utils.getTable("qa_common_icon_overrides")
                                 local replaced = 0
                                 for _, item in ipairs(icons_list) do
                                     if temp_overrides[item.name] then
@@ -1259,7 +1239,7 @@ function QA.showIconPicker(on_select, saved_icon, filter, mode, parent_mode)
                                 UIManager:close(self)
                                 UIManager:setDirty("all", "full")
                                 resetSystemTempOverrides()
-                                setTable("qa_common_icon_overrides", {})
+                                Utils.set("qa_common_icon_overrides", {})
                                 picker_cache = {}
                                 UIManager:show(Notification:new{
                                     text = _("All icons reset, restart required"),
@@ -1276,7 +1256,7 @@ function QA.showIconPicker(on_select, saved_icon, filter, mode, parent_mode)
                                 return true
                             end
                             if gx >= btn_x_start + btn_width_sys + 8 and gx < btn_x_start + (btn_width_sys + 8) * 2 then
-                                local all_overrides = getTable("qa_common_icon_overrides")
+                                local all_overrides = Utils.getTable("qa_common_icon_overrides")
                                 local replaced = 0
                                 for _, item in ipairs(icons_list) do
                                     if temp_overrides[item.name] then
@@ -1292,7 +1272,7 @@ function QA.showIconPicker(on_select, saved_icon, filter, mode, parent_mode)
                                 end
                                 UIManager:close(self)
                                 UIManager:setDirty("all", "full")
-                                local overrides = getTable("qa_common_icon_overrides")
+                                local overrides = Utils.getTable("qa_common_icon_overrides")
                                 for k, _ in pairs(overrides) do
                                     overrides[k] = nil
                                 end
@@ -1301,7 +1281,7 @@ function QA.showIconPicker(on_select, saved_icon, filter, mode, parent_mode)
                                         overrides[k] = v
                                     end
                                 end
-                                setTable("qa_common_icon_overrides", overrides)
+                                Utils.set("qa_common_icon_overrides", overrides)
                                 resetSystemTempOverrides()
                                 picker_cache = {}
                                 UIManager:show(Notification:new{
@@ -1611,7 +1591,7 @@ function QA.patchIconWidget()
 
     function IconWidget:init()
         if self.icon then
-            local overrides = getTable("qa_common_icon_overrides")
+            local overrides = Utils.getTable("qa_common_icon_overrides")
             if overrides and overrides[self.icon] then
                 local user_icon = overrides[self.icon]
                 local dir = QA.getIconsDir()

--- a/qui_actions/qa_menu_recorder.lua
+++ b/qui_actions/qa_menu_recorder.lua
@@ -29,9 +29,6 @@ local VerticalSpan = require("ui/widget/verticalspan")
 local PLUGIN_STORE = _G.__QUICKUI_PLUGIN_STORE or {}
 _G.__QUICKUI_PLUGIN_STORE = PLUGIN_STORE
 
-local function getPlugin()
-    return PLUGIN_STORE.plugin_ref
-end
 
 local MenuRecorder = {}
 

--- a/qui_actions/qa_panel.lua
+++ b/qui_actions/qa_panel.lua
@@ -46,49 +46,9 @@ local settings_mod = require("qui_actions/qa_settings")
 local PLUGIN_STORE = _G.__QUICKUI_PLUGIN_STORE or {}
 _G.__QUICKUI_PLUGIN_STORE = PLUGIN_STORE
 
-local function getPlugin()
-    return PLUGIN_STORE.plugin_ref
-end
-
 local QA = {}
 local _qs_refs = nil
 
-
--- ============================================================
--- Configuration - Read from _G.__QUICKUI_CONFIG
--- ============================================================
-
-local function getBool(key)
-    local config = _G.__QUICKUI_CONFIG
-    if config and config[key] ~= nil then
-        return config[key] == true
-    end
-    return false
-end
-
-local function getString(key)
-    local config = _G.__QUICKUI_CONFIG
-    if config and config[key] ~= nil then
-        return config[key]
-    end
-    return ""
-end
-
-local function getNumber(key)
-    local config = _G.__QUICKUI_CONFIG
-    if config and config[key] ~= nil then
-        return config[key]
-    end
-    return 0
-end
-
-local function getQASlots()
-    local config = _G.__QUICKUI_CONFIG
-    if config and config.qa_panel_slots then
-        return config.qa_panel_slots
-    end
-    return {}
-end
 
 -- ============================================================
 -- Initialization
@@ -191,15 +151,15 @@ function QA.buildPanel(touch_menu)
     local padding = Screen:scaleBySize(28)
     local inner_w = panel_w - padding * 2
     local base_btn_size = Screen:scaleBySize(60)
-    local button_scale = getNumber("qa_panel_button_size_pct") / 100
+    local button_scale = Utils.getNumber("qa_panel_button_size_pct") / 100
     if button_scale <= 0 then button_scale = 1 end
     local btn_size = math.floor(base_btn_size * button_scale)
     local icon_size = math.floor(btn_size * 0.52)
-    local label_fs = math.max(6, math.floor(15 * (getNumber("qa_panel_label_scale_pct") / 100)))
+    local label_fs = math.max(6, math.floor(15 * (Utils.getNumber("qa_panel_label_scale_pct") / 100)))
     local label_face = Utils.getFontFace("cfont", label_fs)
     local medium_face = Utils.getFontFace("ffont", Utils.scaleBySize(14))
     local border_sz = 1
-    local shape = getString("qa_panel_shape")
+    local shape = Utils.getString("qa_panel_shape")
     if shape == "" then shape = "round" end
     local is_bare = (shape == "bare")
 
@@ -234,7 +194,7 @@ function QA.buildPanel(touch_menu)
             corner_r = math.floor(btn_size / 4)
         end
 
-        local bg = getString("qa_panel_bg")
+        local bg = Utils.getString("qa_panel_bg")
         if bg == "" then bg = "flat" end
         local current_border = 0
         local bg_color = nil
@@ -316,7 +276,7 @@ function QA.buildPanel(touch_menu)
             },
         }
 
-        if getBool("qa_panel_button_hold_edit") then
+        if Utils.getBool("qa_panel_button_hold_edit") then
             table.insert(zones, {
                 id = "btn_hold_" .. action_id,
                 ges = "hold",
@@ -352,7 +312,7 @@ function QA.buildPanel(touch_menu)
         btn_wrapper.onShow = function() end
 
         local vg = VerticalGroup:new{ align = "center", btn_wrapper }
-        if getBool("qa_panel_labels") then
+        if Utils.getBool("qa_panel_labels") then
             local lbl_w = btn_size + Screen:scaleBySize(6)
             table.insert(vg, VerticalSpan:new{ width = Screen:scaleBySize(2) })
             table.insert(vg, CenterContainer:new{
@@ -371,7 +331,7 @@ function QA.buildPanel(touch_menu)
         return vg, btn_frame
     end
 
-    local context_filter_enabled = getBool("qa_common_context_filter")
+    local context_filter_enabled = Utils.getBool("qa_common_context_filter")
     local current_view = "filemanager"
     if context_filter_enabled then
         local RUI = require("apps/reader/readerui")
@@ -379,7 +339,7 @@ function QA.buildPanel(touch_menu)
         current_view = in_reader and "reader" or "filemanager"
     end
 
-    local slots = getQASlots()
+    local slots = Utils.getTable("qa_panel_slots")
     local visible_slots = {}
     for __, id in ipairs(slots) do
         local action = getAction(id)
@@ -455,7 +415,7 @@ function QA.buildPanel(touch_menu)
     }
 
     -- Frontlight slider
-    if getBool("qa_panel_frontlight") and Device:hasFrontlight() then
+    if Utils.getBool("qa_panel_frontlight") and Device:hasFrontlight() then
         local powerd = Device:getPowerDevice()
         local fl = {
             min = powerd.fl_min,
@@ -468,7 +428,7 @@ function QA.buildPanel(touch_menu)
         local slider_width = inner_w - 2 * small_btn_w - max_btn_w - 3 * slider_gap
 
         local fl_label = nil
-        if getBool("qa_panel_slider_show_value") then
+        if Utils.getBool("qa_panel_slider_show_value") then
             fl_label = TextWidget:new{
                 text = _("Frontlight") .. ": " .. tostring(fl.cur),
                 face = medium_face,
@@ -570,7 +530,7 @@ function QA.buildPanel(touch_menu)
     end
 
     -- Warmth slider
-    if getBool("qa_panel_warmth") and Device:hasNaturalLight() then
+    if Utils.getBool("qa_panel_warmth") and Device:hasNaturalLight() then
         local powerd = Device:getPowerDevice()
         local nl = {
             min = powerd.fl_warmth_min,
@@ -583,7 +543,7 @@ function QA.buildPanel(touch_menu)
         local warmth_slider_w = inner_w - 2 * small_btn_w - max_btn_w - 3 * slider_gap
 
         local nl_label = nil
-        if getBool("qa_panel_slider_show_value") then
+        if Utils.getBool("qa_panel_slider_show_value") then
             nl_label = TextWidget:new{
                 text = _("Warmth") .. ": " .. tostring(nl.cur),
                 face = medium_face,
@@ -673,7 +633,7 @@ function QA.buildPanel(touch_menu)
     }
 
     function ic:onHoldPanel()
-        if not getBool("qa_panel_settings_on_hold") then return false end
+        if not Utils.getBool("qa_panel_settings_on_hold") then return false end
         if settings_mod and settings_mod.showPanelSettings then
             settings_mod.showPanelSettings()
         end
@@ -698,7 +658,7 @@ function QA.patchTouchMenu()
             end
         end
         table.insert(menu.tab_item_table, 1, {
-            icon = getString("qa_common_tab_icon"),
+            icon = Utils.getString("qa_common_tab_icon"),
             remember = false,
             _qa_panel = true,
         })

--- a/qui_actions/qa_settings.lua
+++ b/qui_actions/qa_settings.lua
@@ -72,142 +72,6 @@ function QA.setBottombar(bb)
 end
 
 -- ============================================================
--- Configuration - Read from _G.__QUICKUI_CONFIG
--- ============================================================
-
-local function getPlugin()
-    return PLUGIN_STORE.plugin_ref
-end
-
-local function getBool(key, default)
-    local config = _G.__QUICKUI_CONFIG
-    if config and config[key] ~= nil then
-        return config[key]
-    end
-    return default or false
-end
-
-local function setBool(key, value)
-    local config = _G.__QUICKUI_CONFIG
-    if config then
-        config[key] = value
-        Utils.saveConfig()
-    end
-end
-
-local function getString(key, default)
-    local config = _G.__QUICKUI_CONFIG
-    if config and config[key] ~= nil then
-        return config[key]
-    end
-    return default or ""
-end
-
-local function setString(key, value)
-    local config = _G.__QUICKUI_CONFIG
-    if config then
-        config[key] = tostring(value)
-        Utils.saveConfig()
-    end
-end
-
-local function getNumber(key, default)
-    local config = _G.__QUICKUI_CONFIG
-    if config and type(config[key]) == "number" then
-        return config[key]
-    end
-    return default or 0
-end
-
-local function setNumber(key, value)
-    local config = _G.__QUICKUI_CONFIG
-    if config then
-        config[key] = tonumber(value) or 0
-        Utils.saveConfig()
-    end
-end
-
-local function getTable(key)
-    local config = _G.__QUICKUI_CONFIG
-    if config and config[key] ~= nil then
-        return config[key]
-    end
-    return {}
-end
-
-local function setTable(key, value)
-    local config = _G.__QUICKUI_CONFIG
-    if config then
-        config[key] = value
-        Utils.saveConfig()
-    end
-end
-
-local function getQASlots()
-    local config = _G.__QUICKUI_CONFIG
-    if config and config.qa_panel_slots then
-        return config.qa_panel_slots
-    end
-    return {}
-end
-
-local function saveQASlots(slots)
-    local config = _G.__QUICKUI_CONFIG
-    if config then
-        config.qa_panel_slots = slots
-        Utils.saveConfig()
-    end
-end
-
-local function getCustomList()
-    local config = _G.__QUICKUI_CONFIG
-    if config and config.qa_common_custom_list then
-        return config.qa_common_custom_list
-    end
-    return {}
-end
-
-local function setCustomList(value)
-    local config = _G.__QUICKUI_CONFIG
-    if config then
-        config.qa_common_custom_list = value
-        Utils.saveConfig()
-    end
-end
-
-local function getCustom()
-    local config = _G.__QUICKUI_CONFIG
-    if config and config.qa_common_custom then
-        return config.qa_common_custom
-    end
-    return {}
-end
-
-local function setCustom(value)
-    local config = _G.__QUICKUI_CONFIG
-    if config then
-        config.qa_common_custom = value
-        Utils.saveConfig()
-    end
-end
-
-local function getBuiltinOverrides()
-    local config = _G.__QUICKUI_CONFIG
-    if config and config.qa_common_builtin_overrides then
-        return config.qa_common_builtin_overrides
-    end
-    return {}
-end
-
-local function setBuiltinOverrides(value)
-    local config = _G.__QUICKUI_CONFIG
-    if config then
-        config.qa_common_builtin_overrides = value
-        Utils.saveConfig()
-    end
-end
-
--- ============================================================
 -- Forward to actions module
 -- ============================================================
 
@@ -462,9 +326,9 @@ function QA.showEditActionDialog(action_id, on_done, source)
         if source == "bottombar" then
             local bb = PLUGIN_STORE.bottombar
             if not bb then return nil, 0 end
-            list = bb.getTabs()
+            list = Utils.get("qa_bb_tabs", {})
         else
-            list = getQASlots()
+            list = Utils.getTable("qa_panel_slots")
         end
         for i, id in ipairs(list) do
             if id == action_id then
@@ -477,14 +341,14 @@ function QA.showEditActionDialog(action_id, on_done, source)
     -- Remove from current list
     local function removeFromList()
         if source == "bottombar" then
-            local tabs = PLUGIN_STORE.bottombar and PLUGIN_STORE.bottombar.getTabs() or {}
+            local tabs = Utils.get("qa_bb_tabs", {})
             local new_tabs = {}
             for __, id in ipairs(tabs) do
                 if id ~= action_id then
                     table.insert(new_tabs, id)
                 end
             end
-            setTable("qa_bb_tabs", new_tabs)
+            Utils.set("qa_bb_tabs", new_tabs)
             if PLUGIN_STORE.bottombar then PLUGIN_STORE.bottombar.refresh() end
         else
             actions.removeFromPanel(action_id, nil)
@@ -494,7 +358,7 @@ function QA.showEditActionDialog(action_id, on_done, source)
     -- Move left in current list
     local function moveLeft()
         if source == "bottombar" then
-            local tabs = PLUGIN_STORE.bottombar and PLUGIN_STORE.bottombar.getTabs() or {}
+            local tabs = Utils.get("qa_bb_tabs", {})
             local idx = nil
             for i, id in ipairs(tabs) do
                 if id == action_id then
@@ -504,11 +368,11 @@ function QA.showEditActionDialog(action_id, on_done, source)
             end
             if idx and idx > 1 then
                 tabs[idx], tabs[idx-1] = tabs[idx-1], tabs[idx]
-                setTable("qa_bb_tabs", tabs)
+                Utils.set("qa_bb_tabs", tabs)
                 if PLUGIN_STORE.bottombar then PLUGIN_STORE.bottombar.refresh() end
             end
         else
-            local slots = getQASlots()
+            local slots = Utils.getTable("qa_panel_slots")
             local idx = nil
             for i, id in ipairs(slots) do
                 if id == action_id then
@@ -518,7 +382,7 @@ function QA.showEditActionDialog(action_id, on_done, source)
             end
             if idx and idx > 1 then
                 slots[idx], slots[idx-1] = slots[idx-1], slots[idx]
-                saveQASlots(slots)
+                Utils.set("qa_panel_slots", slots)
             end
         end
     end
@@ -526,7 +390,7 @@ function QA.showEditActionDialog(action_id, on_done, source)
     -- Move right in current list
     local function moveRight()
         if source == "bottombar" then
-            local tabs = PLUGIN_STORE.bottombar and PLUGIN_STORE.bottombar.getTabs() or {}
+            local tabs = Utils.get("qa_bb_tabs", {})
             local idx = nil
             for i, id in ipairs(tabs) do
                 if id == action_id then
@@ -536,11 +400,11 @@ function QA.showEditActionDialog(action_id, on_done, source)
             end
             if idx and idx < #tabs then
                 tabs[idx], tabs[idx+1] = tabs[idx+1], tabs[idx]
-                setTable("qa_bb_tabs", tabs)
+                Utils.set("qa_bb_tabs", tabs)
                 if PLUGIN_STORE.bottombar then PLUGIN_STORE.bottombar.refresh() end
             end
         else
-            local slots = getQASlots()
+            local slots = Utils.getTable("qa_panel_slots")
             local idx = nil
             for i, id in ipairs(slots) do
                 if id == action_id then
@@ -550,7 +414,7 @@ function QA.showEditActionDialog(action_id, on_done, source)
             end
             if idx and idx < #slots then
                 slots[idx], slots[idx+1] = slots[idx+1], slots[idx]
-                saveQASlots(slots)
+                Utils.set("qa_panel_slots", slots)
             end
         end
     end
@@ -558,7 +422,7 @@ function QA.showEditActionDialog(action_id, on_done, source)
     -- Open sort dialog for current list
     local function openSortDialog()
         if source == "bottombar" then
-            local tabs = PLUGIN_STORE.bottombar and PLUGIN_STORE.bottombar.getTabs() or {}
+            local tabs = Utils.get("qa_bb_tabs", {})
             local sort_items = {}
             for i, id in ipairs(tabs) do
                 sort_items[#sort_items + 1] = { text = getLabelForAction(id), orig_item = id }
@@ -572,14 +436,14 @@ function QA.showEditActionDialog(action_id, on_done, source)
                     for j = 1, #sort_items do
                         new_tabs[#new_tabs + 1] = sort_items[j].orig_item
                     end
-                    setTable("qa_bb_tabs", new_tabs)
+                    Utils.set("qa_bb_tabs", new_tabs)
                     if PLUGIN_STORE.bottombar then PLUGIN_STORE.bottombar.refresh() end
                     if on_done then on_done() end
                 end,
             }
             UIManager:show(sort_dialog)
         else
-            local slots = getQASlots()
+            local slots = Utils.getTable("qa_panel_slots")
             local sort_items = {}
             for i, id in ipairs(slots) do
                 sort_items[#sort_items + 1] = { text = getLabelForAction(id), orig_item = id }
@@ -593,7 +457,7 @@ function QA.showEditActionDialog(action_id, on_done, source)
                     for j = 1, #sort_items do
                         new_slots[#new_slots + 1] = sort_items[j].orig_item
                     end
-                    saveQASlots(new_slots)
+                    Utils.set("qa_panel_slots", new_slots)
                     QA.refreshQuickPanel()
                     if on_done then on_done() end
                 end,
@@ -679,14 +543,14 @@ function QA.showEditActionDialog(action_id, on_done, source)
             end
             closeSettingsDialog()
 
-            local overrides = getBuiltinOverrides()
+            local overrides = Utils.getTable("qa_common_builtin_overrides")
             if not overrides[action_id] then
                 overrides[action_id] = {}
             end
             overrides[action_id].label = new_label
             overrides[action_id].icon = current_icon
             overrides[action_id].view = current_view
-            setBuiltinOverrides(overrides)
+            Utils.set("qa_common_builtin_overrides", overrides)
             if PLUGIN_STORE.bottombar then
                  PLUGIN_STORE.bottombar.refresh()
             end
@@ -761,7 +625,7 @@ end
 function QA.showCustomQADialog(qa_id, on_done, source)
     closeSettingsDialog()
 
-    local custom = getCustom()
+    local custom = Utils.getTable("qa_common_custom")
     local cfg = qa_id and custom[qa_id] or {}
     local chosen_icon = cfg.icon
     local dlg_title = qa_id and _("Edit Quick Action") or _("New Quick Action")
@@ -810,9 +674,9 @@ function QA.showCustomQADialog(qa_id, on_done, source)
         if source == "bottombar" then
             local bb = PLUGIN_STORE.bottombar
             if not bb then return nil, 0 end
-            list = bb.getTabs()
+            list = Utils.get("qa_bb_tabs", {})
         else
-            list = getQASlots()
+            list = Utils.getTable("qa_panel_slots")
         end
         for i, id in ipairs(list) do
             if id == qa_id then
@@ -825,31 +689,31 @@ function QA.showCustomQADialog(qa_id, on_done, source)
     -- Remove from current list
     local function removeFromList()
         if source == "bottombar" then
-            local tabs = PLUGIN_STORE.bottombar and PLUGIN_STORE.bottombar.getTabs() or {}
+            local tabs = Utils.get("qa_bb_tabs", {})
             local new_tabs = {}
             for __, id in ipairs(tabs) do
                 if id ~= qa_id then
                     table.insert(new_tabs, id)
                 end
             end
-            setTable("qa_bb_tabs", new_tabs)
+            Utils.set("qa_bb_tabs", new_tabs)
             if PLUGIN_STORE.bottombar then PLUGIN_STORE.bottombar.refresh() end
         else
-            local slots = getQASlots()
+            local slots = Utils.getTable("qa_panel_slots")
             local new_slots = {}
             for __, sid in ipairs(slots) do
                 if sid ~= qa_id then
                     table.insert(new_slots, sid)
                 end
             end
-            saveQASlots(new_slots)
+            Utils.set("qa_panel_slots", new_slots)
         end
     end
 
     -- Move left in current list
     local function moveLeft()
         if source == "bottombar" then
-            local tabs = PLUGIN_STORE.bottombar and PLUGIN_STORE.bottombar.getTabs() or {}
+            local tabs = Utils.get("qa_bb_tabs", {})
             local idx = nil
             for i, id in ipairs(tabs) do
                 if id == qa_id then
@@ -859,11 +723,11 @@ function QA.showCustomQADialog(qa_id, on_done, source)
             end
             if idx and idx > 1 then
                 tabs[idx], tabs[idx-1] = tabs[idx-1], tabs[idx]
-                setTable("qa_bb_tabs", tabs)
+                Utils.set("qa_bb_tabs", tabs)
                 if PLUGIN_STORE.bottombar then PLUGIN_STORE.bottombar.refresh() end
             end
         else
-            local slots = getQASlots()
+            local slots = Utils.getTable("qa_panel_slots")
             local idx = nil
             for i, id in ipairs(slots) do
                 if id == qa_id then
@@ -873,7 +737,7 @@ function QA.showCustomQADialog(qa_id, on_done, source)
             end
             if idx and idx > 1 then
                 slots[idx], slots[idx-1] = slots[idx-1], slots[idx]
-                saveQASlots(slots)
+                Utils.set("qa_panel_slots", slots)
             end
         end
     end
@@ -881,7 +745,7 @@ function QA.showCustomQADialog(qa_id, on_done, source)
     -- Move right in current list
     local function moveRight()
         if source == "bottombar" then
-            local tabs = PLUGIN_STORE.bottombar and PLUGIN_STORE.bottombar.getTabs() or {}
+            local tabs = Utils.get("qa_bb_tabs", {})
             local idx = nil
             for i, id in ipairs(tabs) do
                 if id == qa_id then
@@ -891,11 +755,11 @@ function QA.showCustomQADialog(qa_id, on_done, source)
             end
             if idx and idx < #tabs then
                 tabs[idx], tabs[idx+1] = tabs[idx+1], tabs[idx]
-                setTable("qa_bb_tabs", tabs)
+                Utils.set("qa_bb_tabs", tabs)
                 if PLUGIN_STORE.bottombar then PLUGIN_STORE.bottombar.refresh() end
             end
         else
-            local slots = getQASlots()
+            local slots = Utils.getTable("qa_panel_slots")
             local idx = nil
             for i, id in ipairs(slots) do
                 if id == qa_id then
@@ -905,7 +769,7 @@ function QA.showCustomQADialog(qa_id, on_done, source)
             end
             if idx and idx < #slots then
                 slots[idx], slots[idx+1] = slots[idx+1], slots[idx]
-                saveQASlots(slots)
+                Utils.set("qa_panel_slots", slots)
             end
         end
     end
@@ -913,7 +777,7 @@ function QA.showCustomQADialog(qa_id, on_done, source)
     -- Open sort dialog for current list
     local function openSortDialog()
         if source == "bottombar" then
-            local tabs = PLUGIN_STORE.bottombar and PLUGIN_STORE.bottombar.getTabs() or {}
+            local tabs = Utils.get("qa_bb_tabs", {})
             local sort_items = {}
             for i, id in ipairs(tabs) do
                 sort_items[#sort_items + 1] = { text = getLabelForAction(id), orig_item = id }
@@ -927,14 +791,14 @@ function QA.showCustomQADialog(qa_id, on_done, source)
                     for j = 1, #sort_items do
                         new_tabs[#new_tabs + 1] = sort_items[j].orig_item
                     end
-                    setTable("qa_bb_tabs", new_tabs)
+                    Utils.set("qa_bb_tabs", new_tabs)
                     if PLUGIN_STORE.bottombar then PLUGIN_STORE.bottombar.refresh() end
                     if on_done then on_done() end
                 end,
             }
             UIManager:show(sort_dialog)
         else
-            local slots = getQASlots()
+            local slots = Utils.getTable("qa_panel_slots")
             local sort_items = {}
             for i, id in ipairs(slots) do
                 sort_items[#sort_items + 1] = { text = getLabelForAction(id), orig_item = id }
@@ -948,7 +812,7 @@ function QA.showCustomQADialog(qa_id, on_done, source)
                     for j = 1, #sort_items do
                         new_slots[#new_slots + 1] = sort_items[j].orig_item
                     end
-                    saveQASlots(new_slots)
+                    Utils.set("qa_panel_slots", new_slots)
                     QA.refreshQuickPanel()
                     if on_done then on_done() end
                 end,
@@ -958,7 +822,7 @@ function QA.showCustomQADialog(qa_id, on_done, source)
     end
 
     local function commitQA(final_label, path, collections, icon, plugin_key, plugin_method, dispatcher_action, dispatcher_value, menu_path, user_view)
-        local list = getCustomList()
+        local list = Utils.getTable("qa_common_custom_list")
         local max_n = 0
         for __, id in ipairs(list) do
             local n = tonumber(id:match("^custom_qa_(%d+)$"))
@@ -966,8 +830,8 @@ function QA.showCustomQADialog(qa_id, on_done, source)
         end
         local final_id = qa_id or ("custom_qa_" .. (max_n + 1))
 
-        local custom_tbl = getCustom()
-        local custom_list = getCustomList()
+        local custom_tbl = Utils.getTable("qa_common_custom")
+        local custom_list = Utils.getTable("qa_common_custom_list")
 
         local action_type = nil
         local default_view = "common"
@@ -1027,14 +891,14 @@ function QA.showCustomQADialog(qa_id, on_done, source)
         end
 
         custom_tbl[final_id] = cfg_table
-        setCustom(custom_tbl)
+        Utils.set("qa_common_custom", custom_tbl)
         if PLUGIN_STORE.bottombar then
             PLUGIN_STORE.bottombar.refresh()
         end
 
-        local auto_add = getBool("qa_common_auto_add_to_panel")
+        local auto_add = Utils.getBool("qa_common_auto_add_to_panel")
         if source ~= "bottombar" and auto_add then
-            local slots = getQASlots()
+            local slots = Utils.getTable("qa_panel_slots")
             local already_exists = false
             for __, sid in ipairs(slots) do
                 if sid == final_id then
@@ -1045,7 +909,7 @@ function QA.showCustomQADialog(qa_id, on_done, source)
             if not already_exists then
                 if #slots < 66 then
                     slots[#slots + 1] = final_id
-                    saveQASlots(slots)
+                    Utils.set("qa_panel_slots", slots)
                 else
                     UIManager:show(InfoMessage:new{
                         text = string.format(_("Panel is full (max 66 buttons), cannot auto-add.")),
@@ -1057,7 +921,7 @@ function QA.showCustomQADialog(qa_id, on_done, source)
 
         if not qa_id then
             custom_list[#custom_list + 1] = final_id
-            setCustomList(custom_list)
+            Utils.set("qa_common_custom_list", custom_list)
         end
 
         if on_done then on_done() end
@@ -1364,17 +1228,17 @@ function QA.showCustomQADialog(qa_id, on_done, source)
                     ok_text = _("Delete"),
                     cancel_text = _("Cancel"),
                     ok_callback = function()
-                        local custom_tbl = getCustom()
+                        local custom_tbl = Utils.getTable("qa_common_custom")
                         custom_tbl[qa_id] = nil
-                        setCustom(custom_tbl)
-                        local list = getCustomList()
+                        Utils.set("qa_common_custom", custom_tbl)
+                        local list = Utils.getTable("qa_common_custom_list")
                         local new_list = {}
                         for __, id in ipairs(list) do
                             if id ~= qa_id then
                                 table.insert(new_list, id)
                             end
                         end
-                        setCustomList(new_list)
+                        Utils.set("qa_common_custom_list", new_list)
                         removeFromList()
                         if on_done then on_done() end
                     end,
@@ -1536,7 +1400,7 @@ end
 -- ============================================================
 
 function QA.showAddButtonMenu(touch_menu, on_back, filtered_actions)
-    local slots = getQASlots()
+    local slots = Utils.getTable("qa_panel_slots")
     local slot_set = {}
     for __, id in ipairs(slots) do
         slot_set[id] = true
@@ -1631,10 +1495,10 @@ function QA.showAddButtonMenu(touch_menu, on_back, filtered_actions)
         {
             text = _("Frontlight Slider"),
             checked_func = function()
-                return getBool("qa_panel_frontlight")
+                return Utils.getBool("qa_panel_frontlight")
             end,
             callback = function(touchmenu_instance)
-                setBool("qa_panel_frontlight", not getBool("qa_panel_frontlight"))
+                Utils.set("qa_panel_frontlight", not Utils.getBool("qa_panel_frontlight"))
                 if touchmenu_instance then
                     touchmenu_instance:updateItems()
                 end
@@ -1652,10 +1516,10 @@ function QA.showAddButtonMenu(touch_menu, on_back, filtered_actions)
             {
                 text = _("Warmth Slider"),
                 checked_func = function()
-                    return getBool("qa_panel_warmth")
+                    return Utils.getBool("qa_panel_warmth")
                 end,
                 callback = function(touchmenu_instance)
-                    setBool("qa_panel_warmth", not getBool("qa_panel_warmth"))
+                    Utils.set("qa_panel_warmth", not Utils.getBool("qa_panel_warmth"))
                     if touchmenu_instance then
                         touchmenu_instance:updateItems()
                     end
@@ -1673,10 +1537,10 @@ function QA.showAddButtonMenu(touch_menu, on_back, filtered_actions)
         {
             text = _("Show Slider Value"),
             checked_func = function()
-                return getBool("qa_panel_slider_show_value")
+                return Utils.getBool("qa_panel_slider_show_value")
             end,
             callback = function(touchmenu_instance)
-                setBool("qa_panel_slider_show_value", not getBool("qa_panel_slider_show_value"))
+                Utils.set("qa_panel_slider_show_value", not Utils.getBool("qa_panel_slider_show_value"))
                 if touchmenu_instance then
                     touchmenu_instance:updateItems()
                 end
@@ -1704,7 +1568,7 @@ function QA.showAddButtonMenu(touch_menu, on_back, filtered_actions)
             text = all_checked and "☑ " .. _("Deselect All") or "☐ " .. _("Select All"),
             callback = function(touchmenu_instance)
                 local is_all_checked = getAllChecked()
-                local current_slots = getQASlots()
+                local current_slots = Utils.getTable("qa_panel_slots")
                 local new_slots = {}
 
                 if is_all_checked then
@@ -1738,7 +1602,7 @@ function QA.showAddButtonMenu(touch_menu, on_back, filtered_actions)
                     end
                 end
 
-                saveQASlots(new_slots)
+                Utils.set("qa_panel_slots", new_slots)
                 if touchmenu_instance then
                     touchmenu_instance:updateItems()
                 end
@@ -1765,7 +1629,7 @@ function QA.showAddButtonMenu(touch_menu, on_back, filtered_actions)
             {
                 text = display_text,
                 callback = function(touchmenu_instance)
-                    local current_slots = getQASlots()
+                    local current_slots = Utils.getTable("qa_panel_slots")
                     local found = false
                     for j = 1, #current_slots do
                         if current_slots[j] == action.id then
@@ -1780,7 +1644,7 @@ function QA.showAddButtonMenu(touch_menu, on_back, filtered_actions)
                                 new_slots[#new_slots + 1] = current_slots[j]
                             end
                         end
-                        saveQASlots(new_slots)
+                        Utils.set("qa_panel_slots", new_slots)
                     else
                         if #current_slots >= 66 then
                             UIManager:show(Notification:new{
@@ -1790,7 +1654,7 @@ function QA.showAddButtonMenu(touch_menu, on_back, filtered_actions)
                             return
                         end
                         current_slots[#current_slots + 1] = action.id
-                        saveQASlots(current_slots)
+                        Utils.set("qa_panel_slots", current_slots)
                     end
                     if touchmenu_instance then
                         touchmenu_instance:updateItems()
@@ -1860,10 +1724,10 @@ local function getCustomItems(touch_menu)
         end
     end
 
-    local custom_list = getCustomList()
+    local custom_list = Utils.getTable("qa_common_custom_list")
     for i = 1, #custom_list do
         local id = custom_list[i]
-        local cfg = getCustom()[id]
+        local cfg = Utils.getTable("qa_common_custom")[id]
         if cfg then
             local symbol = getActionSymbol(id)
             local view_tag = " [" .. getActionViewFinal(id) .. "]"
@@ -1877,17 +1741,17 @@ local function getCustomItems(touch_menu)
                     end)
                 end,
                 on_delete = function()
-                    local custom_tbl = getCustom()
+                    local custom_tbl = Utils.getTable("qa_common_custom")
                     custom_tbl[id] = nil
-                    setCustom(custom_tbl)
-                    local list = getCustomList()
+                    Utils.set("qa_common_custom", custom_tbl)
+                    local list = Utils.getTable("qa_common_custom_list")
                     local new_list = {}
                     for __, lid in ipairs(list) do
                         if lid ~= id then
                             table.insert(new_list, lid)
                         end
                     end
-                    setCustomList(new_list)
+                    Utils.set("qa_common_custom_list", new_list)
                     QA.refreshQuickPanel()
                 end,
             }
@@ -1904,14 +1768,14 @@ end
 function QA.getQuickActionsSubmenu()
     local items = {}
 
-    local auto_add = getBool("qa_common_auto_add_to_panel")
+    local auto_add = Utils.getBool("qa_common_auto_add_to_panel")
     items[#items + 1] = {
         text = _("Auto-add to panel on save"),
         checked_func = function()
-            return getBool("qa_common_auto_add_to_panel")
+            return Utils.getBool("qa_common_auto_add_to_panel")
         end,
         callback = function(touchmenu_instance)
-            setBool("qa_common_auto_add_to_panel", not getBool("qa_common_auto_add_to_panel"))
+            Utils.set("qa_common_auto_add_to_panel", not Utils.getBool("qa_common_auto_add_to_panel"))
             if touchmenu_instance then
                 touchmenu_instance:updateItems()
             end
@@ -1971,7 +1835,7 @@ function QA.getPanelMenuItems()
     local items = {}
 
     items[#items + 1] = {
-        text = _("Tab Icon") .. ": " .. getString("qa_common_tab_icon", "star.empty"),
+        text = _("Tab Icon") .. ": " .. Utils.getString("qa_common_tab_icon", "star.empty"),
         close_on_click = true,
         callback = function()
             closeSettingsDialog()
@@ -1980,7 +1844,7 @@ function QA.getPanelMenuItems()
                     if file_path then
                         local filename_with_ext = file_path:match("([^/]+)$")
                         local filename = filename_with_ext:gsub("%.[^%.]+$", "")
-                        setString("qa_common_tab_icon", filename)
+                        Utils.set("qa_common_tab_icon", filename)
                         UIManager:show(ConfirmBox:new{
                             text = _("Restart required.\n\nRestart KOReader now?"),
                             ok_text = _("Restart"),
@@ -2001,7 +1865,7 @@ function QA.getPanelMenuItems()
         text = _("Arrange Buttons"),
         close_on_click = true,
         callback = function()
-            local slots = getQASlots()
+            local slots = Utils.getTable("qa_panel_slots")
             local sort_items = {}
             for i, id in ipairs(slots) do
                 sort_items[#sort_items + 1] = { text = getLabelForAction(id), orig_item = id }
@@ -2015,7 +1879,7 @@ function QA.getPanelMenuItems()
                     for j = 1, #sort_items do
                         new_slots[#new_slots + 1] = sort_items[j].orig_item
                     end
-                    saveQASlots(new_slots)
+                    Utils.set("qa_panel_slots", new_slots)
                     QA.refreshQuickPanel()
                 end,
             }
@@ -2040,10 +1904,10 @@ function QA.getPanelMenuItems()
                 text = _("Round"),
                 radio = true,
                 checked_func = function()
-                    return getString("qa_panel_shape", "round") == "round"
+                    return Utils.getString("qa_panel_shape", "round") == "round"
                 end,
                 callback = function(touchmenu_instance)
-                    setString("qa_panel_shape", "round")
+                    Utils.set("qa_panel_shape", "round")
                     if touchmenu_instance then
                         touchmenu_instance:updateItems()
                     end
@@ -2054,10 +1918,10 @@ function QA.getPanelMenuItems()
                 text = _("Rounded Square"),
                 radio = true,
                 checked_func = function()
-                    return getString("qa_panel_shape", "round") == "square_round"
+                    return Utils.getString("qa_panel_shape", "round") == "square_round"
                 end,
                 callback = function(touchmenu_instance)
-                    setString("qa_panel_shape", "square_round")
+                    Utils.set("qa_panel_shape", "square_round")
                     if touchmenu_instance then
                         touchmenu_instance:updateItems()
                     end
@@ -2068,10 +1932,10 @@ function QA.getPanelMenuItems()
                 text = _("Bare"),
                 radio = true,
                 checked_func = function()
-                    return getString("qa_panel_shape", "round") == "bare"
+                    return Utils.getString("qa_panel_shape", "round") == "bare"
                 end,
                 callback = function(touchmenu_instance)
-                    setString("qa_panel_shape", "bare")
+                    Utils.set("qa_panel_shape", "bare")
                     if touchmenu_instance then
                         touchmenu_instance:updateItems()
                     end
@@ -2084,17 +1948,17 @@ function QA.getPanelMenuItems()
     items[#items + 1] = {
         text = _("Button Background"),
         enabled = function()
-            return getString("qa_panel_shape", "round") ~= "bare"
+            return Utils.getString("qa_panel_shape", "round") ~= "bare"
         end,
         sub_item_table = {
             {
                 text = _("Transparent"),
                 radio = true,
                 checked_func = function()
-                    return getString("qa_panel_bg", "flat") == "transparent"
+                    return Utils.getString("qa_panel_bg", "flat") == "transparent"
                 end,
                 callback = function(touchmenu_instance)
-                    setString("qa_panel_bg", "transparent")
+                    Utils.set("qa_panel_bg", "transparent")
                     if touchmenu_instance then
                         touchmenu_instance:updateItems()
                     end
@@ -2105,10 +1969,10 @@ function QA.getPanelMenuItems()
                 text = _("Solid"),
                 radio = true,
                 checked_func = function()
-                    return getString("qa_panel_bg", "flat") == "solid"
+                    return Utils.getString("qa_panel_bg", "flat") == "solid"
                 end,
                 callback = function(touchmenu_instance)
-                    setString("qa_panel_bg", "solid")
+                    Utils.set("qa_panel_bg", "solid")
                     if touchmenu_instance then
                         touchmenu_instance:updateItems()
                     end
@@ -2119,10 +1983,10 @@ function QA.getPanelMenuItems()
                 text = _("Light Gray"),
                 radio = true,
                 checked_func = function()
-                    return getString("qa_panel_bg", "flat") == "flat"
+                    return Utils.getString("qa_panel_bg", "flat") == "flat"
                 end,
                 callback = function(touchmenu_instance)
-                    setString("qa_panel_bg", "flat")
+                    Utils.set("qa_panel_bg", "flat")
                     if touchmenu_instance then
                         touchmenu_instance:updateItems()
                     end
@@ -2135,10 +1999,10 @@ function QA.getPanelMenuItems()
     items[#items + 1] = {
         text = _("Show Labels"),
         checked_func = function()
-            return getBool("qa_panel_labels", false)
+            return Utils.getBool("qa_panel_labels", false)
         end,
         callback = function(touchmenu_instance)
-            setBool("qa_panel_labels", not getBool("qa_panel_labels", false))
+            Utils.set("qa_panel_labels", not Utils.getBool("qa_panel_labels", false))
             if touchmenu_instance then
                 touchmenu_instance:updateItems()
             end
@@ -2148,20 +2012,20 @@ function QA.getPanelMenuItems()
 
     items[#items + 1] = {
         text_func = function()
-            return _("Button Size") .. ": " .. getNumber("qa_panel_button_size_pct", 100) .. "%"
+            return _("Button Size") .. ": " .. Utils.getNumber("qa_panel_button_size_pct", 100) .. "%"
         end,
         close_on_click = true,
         callback = function(touchmenu_instance)
             closeSettingsDialog()
             local spin = SpinWidget:new{
                 title_text = _("Button Size"),
-                value = getNumber("qa_panel_button_size_pct", 100),
+                value = Utils.getNumber("qa_panel_button_size_pct", 100),
                 value_min = 60,
                 value_max = 150,
                 value_step = 5,
                 unit = "%",
                 callback = function(spin)
-                    setNumber("qa_panel_button_size_pct", spin.value)
+                    Utils.set("qa_panel_button_size_pct", spin.value)
                     if touchmenu_instance then
                         touchmenu_instance:updateItems()
                     end
@@ -2176,20 +2040,20 @@ function QA.getPanelMenuItems()
 
     items[#items + 1] = {
         text_func = function()
-            return _("Label Size") .. ": " .. getNumber("qa_panel_label_scale_pct", 90) .. "%"
+            return _("Label Size") .. ": " .. Utils.getNumber("qa_panel_label_scale_pct", 90) .. "%"
         end,
         close_on_click = true,
         callback = function(touchmenu_instance)
             closeSettingsDialog()
             local spin = SpinWidget:new{
                 title_text = _("Label Size"),
-                value = getNumber("qa_panel_label_scale_pct", 90),
+                value = Utils.getNumber("qa_panel_label_scale_pct", 90),
                 value_min = 50,
                 value_max = 200,
                 value_step = 10,
                 unit = "%",
                 callback = function(spin)
-                    setNumber("qa_panel_label_scale_pct", spin.value)
+                    Utils.set("qa_panel_label_scale_pct", spin.value)
                     if touchmenu_instance then
                         touchmenu_instance:updateItems()
                     end
@@ -2205,10 +2069,10 @@ function QA.getPanelMenuItems()
     items[#items + 1] = {
         text = _("Long-press button to edit"),
         checked_func = function()
-            return getBool("qa_panel_button_hold_edit", true)
+            return Utils.getBool("qa_panel_button_hold_edit", true)
         end,
         callback = function(touchmenu_instance)
-            setBool("qa_panel_button_hold_edit", not getBool("qa_panel_button_hold_edit", true))
+            Utils.set("qa_panel_button_hold_edit", not Utils.getBool("qa_panel_button_hold_edit", true))
             if touchmenu_instance then
                 touchmenu_instance:updateItems()
             end
@@ -2219,10 +2083,10 @@ function QA.getPanelMenuItems()
     items[#items + 1] = {
         text = _("Long-press tab to open settings"),
         checked_func = function()
-            return getBool("qa_panel_settings_on_hold", true)
+            return Utils.getBool("qa_panel_settings_on_hold", true)
         end,
         callback = function(touchmenu_instance)
-            setBool("qa_panel_settings_on_hold", not getBool("qa_panel_settings_on_hold", true))
+            Utils.set("qa_panel_settings_on_hold", not Utils.getBool("qa_panel_settings_on_hold", true))
             if touchmenu_instance then
                 touchmenu_instance:updateItems()
             end
@@ -2258,10 +2122,10 @@ function QA.getBottomBarMenuItems()
     items[#items + 1] = {
         text = _("Show in Reader"),
         checked_func = function()
-            return getBool("qa_bb_reader_enabled", true)
+            return Utils.getBool("qa_bb_reader_enabled", true)
         end,
         callback = function(touchmenu_instance)
-            setBool("qa_bb_reader_enabled", not getBool("qa_bb_reader_enabled", true))
+            Utils.set("qa_bb_reader_enabled", not Utils.getBool("qa_bb_reader_enabled", true))
             if touchmenu_instance then
                 touchmenu_instance:updateItems()
             end
@@ -2273,10 +2137,10 @@ function QA.getBottomBarMenuItems()
     items[#items + 1] = {
         text = _("Long press to edit"),
         checked_func = function()
-            return getBool("qa_bb_button_hold_edit", true)
+            return Utils.getBool("qa_bb_button_hold_edit", true)
         end,
         callback = function(touchmenu_instance)
-            setBool("qa_bb_button_hold_edit", not getBool("qa_bb_button_hold_edit", true))
+            Utils.set("qa_bb_button_hold_edit", not Utils.getBool("qa_bb_button_hold_edit", true))
             if touchmenu_instance then
                 touchmenu_instance:updateItems()
             end
@@ -2287,10 +2151,10 @@ function QA.getBottomBarMenuItems()
     items[#items + 1] = {
         text = _("Long press to open settings"),
         checked_func = function()
-            return getBool("qa_bb_settings_on_hold", true)
+            return Utils.getBool("qa_bb_settings_on_hold", true)
         end,
         callback = function(touchmenu_instance)
-            setBool("qa_bb_settings_on_hold", not getBool("qa_bb_settings_on_hold", true))
+            Utils.set("qa_bb_settings_on_hold", not Utils.getBool("qa_bb_settings_on_hold", true))
             if touchmenu_instance then
                 touchmenu_instance:updateItems()
             end
@@ -2308,10 +2172,10 @@ function QA.getBottomBarMenuItems()
                 text = _("Default"),
                 radio = true,
                 checked_func = function()
-                    return getString("qa_bb_style", "default") == "default"
+                    return Utils.getString("qa_bb_style", "default") == "default"
                 end,
                 callback = function(touchmenu_instance)
-                    setString("qa_bb_style", "default")
+                    Utils.set("qa_bb_style", "default")
                     if touchmenu_instance then
                         touchmenu_instance:updateItems()
                     end
@@ -2322,10 +2186,10 @@ function QA.getBottomBarMenuItems()
                 text = _("Framed"),
                 radio = true,
                 checked_func = function()
-                    return getString("qa_bb_style", "default") == "framed"
+                    return Utils.getString("qa_bb_style", "default") == "framed"
                 end,
                 callback = function(touchmenu_instance)
-                    setString("qa_bb_style", "framed")
+                    Utils.set("qa_bb_style", "framed")
                     if touchmenu_instance then
                         touchmenu_instance:updateItems()
                     end
@@ -2336,10 +2200,10 @@ function QA.getBottomBarMenuItems()
                 text = _("Bare"),
                 radio = true,
                 checked_func = function()
-                    return getString("qa_bb_style", "default") == "bare"
+                    return Utils.getString("qa_bb_style", "default") == "bare"
                 end,
                 callback = function(touchmenu_instance)
-                    setString("qa_bb_style", "bare")
+                    Utils.set("qa_bb_style", "bare")
                     if touchmenu_instance then
                         touchmenu_instance:updateItems()
                     end
@@ -2356,10 +2220,10 @@ function QA.getBottomBarMenuItems()
                 text = _("Transparent"),
                 radio = true,
                 checked_func = function()
-                    return getBool("qa_bb_transparent", false) == true
+                    return Utils.getBool("qa_bb_transparent", false) == true
                 end,
                 callback = function(touchmenu_instance)
-                    setBool("qa_bb_transparent", true)
+                    Utils.set("qa_bb_transparent", true)
                     if touchmenu_instance then
                         touchmenu_instance:updateItems()
                     end
@@ -2370,10 +2234,10 @@ function QA.getBottomBarMenuItems()
                 text = _("Solid"),
                 radio = true,
                 checked_func = function()
-                    return getBool("qa_bb_transparent", false) == false
+                    return Utils.getBool("qa_bb_transparent", false) == false
                 end,
                 callback = function(touchmenu_instance)
-                    setBool("qa_bb_transparent", false)
+                    Utils.set("qa_bb_transparent", false)
                     if touchmenu_instance then
                         touchmenu_instance:updateItems()
                     end
@@ -2394,7 +2258,7 @@ function QA.getBottomBarMenuItems()
                 })
                 return
             end
-            local tabs = bb.getTabs()
+            local tabs = Utils.get("qa_bb_tabs", {})
             if not tabs or #tabs == 0 then
                 UIManager:show(InfoMessage:new{
                     text = _("No tabs configured"),
@@ -2415,7 +2279,7 @@ function QA.getBottomBarMenuItems()
                     for j = 1, #sort_items do
                         new_tabs[#new_tabs + 1] = sort_items[j].orig_item
                     end
-                    setTable("qa_bb_tabs", new_tabs)
+                    Utils.set("qa_bb_tabs", new_tabs)
                     if bb then bb.refresh() end
                 end,
             }
@@ -2443,10 +2307,10 @@ function QA.getBottomBarMenuItems()
     items[#items + 1] = {
         text = _("Show Labels"),
         checked_func = function()
-            return getBool("qa_bb_labels", false)
+            return Utils.getBool("qa_bb_labels", false)
         end,
         callback = function(touchmenu_instance)
-            setBool("qa_bb_labels", not getBool("qa_bb_labels", false))
+            Utils.set("qa_bb_labels", not Utils.getBool("qa_bb_labels", false))
             if touchmenu_instance then
                 touchmenu_instance:updateItems()
             end
@@ -2456,20 +2320,20 @@ function QA.getBottomBarMenuItems()
 
     items[#items + 1] = {
         text_func = function()
-            return _("Bar Size") .. ": " .. getNumber("qa_bb_size_pct", 100) .. "%"
+            return _("Bar Size") .. ": " .. Utils.getNumber("qa_bb_size_pct", 100) .. "%"
         end,
         close_on_click = true,
         callback = function(touchmenu_instance)
             closeSettingsDialog()
             local spin = SpinWidget:new{
                 title_text = _("Bar Size"),
-                value = getNumber("qa_bb_size_pct", 100),
+                value = Utils.getNumber("qa_bb_size_pct", 100),
                 value_min = 50,
                 value_max = 150,
                 value_step = 10,
                 unit = "%",
                 callback = function(spin)
-                    setNumber("qa_bb_size_pct", spin.value)
+                    Utils.set("qa_bb_size_pct", spin.value)
                     if touchmenu_instance then
                         touchmenu_instance:updateItems()
                     end
@@ -2484,20 +2348,20 @@ function QA.getBottomBarMenuItems()
 
     items[#items + 1] = {
         text_func = function()
-            return _("Icon Size") .. ": " .. getNumber("qa_bb_icon_scale_pct", 100) .. "%"
+            return _("Icon Size") .. ": " .. Utils.getNumber("qa_bb_icon_scale_pct", 100) .. "%"
         end,
         close_on_click = true,
         callback = function(touchmenu_instance)
             closeSettingsDialog()
             local spin = SpinWidget:new{
                 title_text = _("Icon Size"),
-                value = getNumber("qa_bb_icon_scale_pct", 100),
+                value = Utils.getNumber("qa_bb_icon_scale_pct", 100),
                 value_min = 50,
                 value_max = 200,
                 value_step = 10,
                 unit = "%",
                 callback = function(spin)
-                    setNumber("qa_bb_icon_scale_pct", spin.value)
+                    Utils.set("qa_bb_icon_scale_pct", spin.value)
                     if touchmenu_instance then
                         touchmenu_instance:updateItems()
                     end
@@ -2512,20 +2376,20 @@ function QA.getBottomBarMenuItems()
 
     items[#items + 1] = {
         text_func = function()
-            return _("Label Size") .. ": " .. getNumber("qa_bb_label_scale_pct", 100) .. "%"
+            return _("Label Size") .. ": " .. Utils.getNumber("qa_bb_label_scale_pct", 100) .. "%"
         end,
         close_on_click = true,
         callback = function(touchmenu_instance)
             closeSettingsDialog()
             local spin = SpinWidget:new{
                 title_text = _("Label Size"),
-                value = getNumber("qa_bb_label_scale_pct", 100),
+                value = Utils.getNumber("qa_bb_label_scale_pct", 100),
                 value_min = 50,
                 value_max = 200,
                 value_step = 10,
                 unit = "%",
                 callback = function(spin)
-                    setNumber("qa_bb_label_scale_pct", spin.value)
+                    Utils.set("qa_bb_label_scale_pct", spin.value)
                     if touchmenu_instance then
                         touchmenu_instance:updateItems()
                     end
@@ -2574,7 +2438,7 @@ function QA.getInterfaceFilterMenuItems()
             checked_func = function()
                 local current_actions = actions.getAllAvailableActions()
                 for __, action in ipairs(current_actions) do
-                    if action.id and not (getCustom()[action.id] and getCustom()[action.id].action_type == "menu") then
+                    if action.id and not (Utils.getTable("qa_common_custom")[action.id] and Utils.getTable("qa_common_custom")[action.id].action_type == "menu") then
                         if action.view ~= target_view then
                             return false
                         end
@@ -2585,7 +2449,7 @@ function QA.getInterfaceFilterMenuItems()
             enabled = function()
                 local current_actions = actions.getAllAvailableActions()
                 for __, action in ipairs(current_actions) do
-                    if action.id and not (getCustom()[action.id] and getCustom()[action.id].action_type == "menu") then
+                    if action.id and not (Utils.getTable("qa_common_custom")[action.id] and Utils.getTable("qa_common_custom")[action.id].action_type == "menu") then
                         return true
                     end
                 end
@@ -2595,7 +2459,7 @@ function QA.getInterfaceFilterMenuItems()
                 local current_actions = actions.getAllAvailableActions()
                 local all_checked = true
                 for __, action in ipairs(current_actions) do
-                    if action.id and not (getCustom()[action.id] and getCustom()[action.id].action_type == "menu") then
+                    if action.id and not (Utils.getTable("qa_common_custom")[action.id] and Utils.getTable("qa_common_custom")[action.id].action_type == "menu") then
                         if action.view ~= target_view then
                             all_checked = false
                             break
@@ -2605,7 +2469,7 @@ function QA.getInterfaceFilterMenuItems()
 
                 for __, action in ipairs(current_actions) do
                     if not action.id then goto continue end
-                    if getCustom()[action.id] and getCustom()[action.id].action_type == "menu" then
+                    if Utils.getTable("qa_common_custom")[action.id] and Utils.getTable("qa_common_custom")[action.id].action_type == "menu" then
                         goto continue
                     end
                     local current = actions.getActionViewFinal(action.id)
@@ -2628,7 +2492,7 @@ function QA.getInterfaceFilterMenuItems()
 
                 for __, action in ipairs(all_actions) do
                     if not action.id then goto continue end
-                    local is_locked = (getCustom()[action.id] and getCustom()[action.id].action_type == "menu")
+                    local is_locked = (Utils.getTable("qa_common_custom")[action.id] and Utils.getTable("qa_common_custom")[action.id].action_type == "menu")
                     local action_id = action.id
                     table.insert(items, {
                         text_func = function()
@@ -2660,12 +2524,12 @@ function QA.getInterfaceFilterMenuItems()
         {
             text = _("Enable Interface Filter"),
             checked_func = function()
-                return getBool("qa_common_context_filter")
+                return Utils.getBool("qa_common_context_filter")
             end,
             callback = function(touchmenu_instance)
-                local p = getPlugin()
+                local p = PLUGIN_STORE.plugin_ref
                 if p then
-                    _G.__QUICKUI_CONFIG.qa_common_context_filter = not getBool("qa_common_context_filter")
+                    _G.__QUICKUI_CONFIG.qa_common_context_filter = not Utils.getBool("qa_common_context_filter")
                     Utils.saveConfig()
                     if touchmenu_instance then
                         touchmenu_instance:updateItems()
@@ -2708,7 +2572,7 @@ function QA.getInterfaceFilterMenuItems()
                     ok_text = _("Reset"),
                     cancel_text = _("Cancel"),
                     ok_callback = function()
-                        local p = getPlugin()
+                        local p = PLUGIN_STORE.plugin_ref
                         if p then
                             _G.__QUICKUI_CONFIG.qa_common_builtin_overrides = {}
                             local custom = _G.__QUICKUI_CONFIG.qa_common_custom or {}
@@ -2747,11 +2611,11 @@ function QA.buildRootMenuItems()
     table.insert(items, {
         text = _("Enable Panel"),
         checked_func = function()
-            return getBool("qa_panel_enabled")
+            return Utils.getBool("qa_panel_enabled")
         end,
         callback = function()
-            local new_val = not getBool("qa_panel_enabled")
-            setBool("qa_panel_enabled", new_val)
+            local new_val = not Utils.getBool("qa_panel_enabled")
+            Utils.set("qa_panel_enabled", new_val)
             local fm = require("apps/filemanager/filemanager").instance
             if fm and fm.menu and fm.menu.menu_container and fm.menu.menu_container[1] then
                 fm.menu.menu_container[1]:updateItems()
@@ -2774,11 +2638,11 @@ function QA.buildRootMenuItems()
     table.insert(items, {
         text = _("Enable Bottom Bar"),
         checked_func = function()
-            return getBool("qa_bb_enabled")
+            return Utils.getBool("qa_bb_enabled")
         end,
         callback = function()
-            local new_val = not getBool("qa_bb_enabled")
-            setBool("qa_bb_enabled", new_val)
+            local new_val = not Utils.getBool("qa_bb_enabled")
+            Utils.set("qa_bb_enabled", new_val)
             local bb = PLUGIN_STORE.bottombar
             if bb then
                 bb.refresh()

--- a/qui_actions/qa_uifont.lua
+++ b/qui_actions/qa_uifont.lua
@@ -45,34 +45,6 @@ local _font_picker_dialog = nil
 local _font_main_dialog = nil
 
 -- ============================================================
--- Configuration - Read/write from _G.__QUICKUI_CONFIG
--- ============================================================
-
-local function getUIFontOverride(key)
-    local config = _G.__QUICKUI_CONFIG
-    if config and config.qa_common_ui_font_overrides then
-        return config.qa_common_ui_font_overrides[key]
-    end
-    return nil
-end
-
-local function setUIFontOverride(key, font_name)
-    local config = _G.__QUICKUI_CONFIG
-    if not config then return end
-    if not config.qa_common_ui_font_overrides then
-        config.qa_common_ui_font_overrides = {}
-    end
-    if font_name then
-        config.qa_common_ui_font_overrides[key] = font_name
-    else
-        config.qa_common_ui_font_overrides[key] = nil
-    end
-    Utils.saveConfig()
-    UIFont.applyUIFontChanges()
-    UIManager:setDirty("all", "full")
-end
-
--- ============================================================
 -- Font List
 -- ============================================================
 
@@ -302,7 +274,8 @@ function UIFont.showFontPickerForUIKey(ui_key, ui_label, on_select, on_cancel)
     end
 
     local all_fonts = UIFont.getAvailableFonts()
-    local current = getUIFontOverride(ui_key) or ""
+    local overrides = Utils.getTable("qa_common_ui_font_overrides")
+    local current = overrides[ui_key] or ""
 
     local buttons = {}
 
@@ -452,13 +425,17 @@ function UIFont.showUIFontSwitcher()
                     item.label,
                     function(new_font)
                         if new_font then
-                            setUIFontOverride(item.key, new_font)
+                            local overrides = Utils.getTable("qa_common_ui_font_overrides")
+                            overrides[item.key] = new_font
+                            Utils.set("qa_common_ui_font_overrides", overrides)
                             UIManager:show(Notification:new{
                                 text = string.format(_("%s set to: %s"), item.label, new_font),
                                 timeout = 2,
                             })
                         else
-                            setUIFontOverride(item.key, nil)
+                            local overrides = Utils.getTable("qa_common_ui_font_overrides")
+                            overrides[item.key] = nil
+                            Utils.set("qa_common_ui_font_overrides", overrides)
                             UIManager:show(Notification:new{
                                 text = string.format(_("%s reset to default"), item.label),
                                 timeout = 2,

--- a/qui_utils.lua
+++ b/qui_utils.lua
@@ -215,6 +215,58 @@ function Utils.getDefaultSettings()
 end
 
 -- ============================================================
+-- Configuration Getters/Setters (统一接口)
+-- ============================================================
+
+function Utils.get(key, default)
+    local config = _G.__QUICKUI_CONFIG
+    if config and config[key] ~= nil then
+        return config[key]
+    end
+    return default
+end
+
+function Utils.getBool(key, default)
+    local val = Utils.get(key, default)
+    if type(val) == "boolean" then
+        return val
+    end
+    return default or false
+end
+
+function Utils.getNumber(key, default)
+    local val = Utils.get(key, default)
+    if type(val) == "number" then
+        return val
+    end
+    return default or 0
+end
+
+function Utils.getString(key, default)
+    local val = Utils.get(key, default)
+    if type(val) == "string" then
+        return val
+    end
+    return default or ""
+end
+
+function Utils.getTable(key)
+    local val = Utils.get(key, {})
+    if type(val) == "table" then
+        return val
+    end
+    return {}
+end
+
+function Utils.set(key, value)
+    local config = _G.__QUICKUI_CONFIG
+    if config then
+        config[key] = value
+        Utils.saveConfig()
+    end
+end
+
+-- ============================================================
 -- Refresh handler registry
 -- ============================================================
 


### PR DESCRIPTION
- unify config access across all QA modules using Utils helpers
- fix: bottom bar remove/move/sort operations now use raw config
- update locales/zh_CN.po.