### PR TITLE
Fix placeholder cover dim effect not showing when selected in filemanager Sync

### DIFF
--- a/changelog.lua
+++ b/changelog.lua
@@ -62,6 +62,7 @@ return {
     "Fix Deselect All not showing when bottom bar tab count reaches max limit",
     "Move Remove button next to Save in built-in action edit dialog",
     "Adjust title and author font size in list view",
+    "Fix placeholder cover dim effect not showing when selected in filemanager",
     "Improve Chinese translations",
 },
 }

--- a/qui_cover.lua
+++ b/qui_cover.lua
@@ -1817,6 +1817,7 @@ function Cover._patchMosaic()
                             padding = 0, bordersize = border,
                             width = portrait_w + 2 * border, height = portrait_h + 2 * border,
                             background = Blitbuffer.COLOR_LIGHT_GRAY,
+                            dim = self.entry and self.entry.dim,
                             CenterContainer:new{
                                 dimen = { w = portrait_w, h = portrait_h },
                                 ImageWidget:new{ image = cover_bb, width = portrait_w, height = portrait_h },
@@ -2373,6 +2374,7 @@ function Cover._patchList()
                 margin = 0,
                 padding = 0,
                 bordersize = border,
+                dim = self.entry and self.entry.dim, 
                 CenterContainer:new{
                     dimen = { w = target_w, h = target_h },
                     wimage,
@@ -2394,6 +2396,7 @@ function Cover._patchList()
                 margin = 0,
                 padding = 0,
                 bordersize = border,
+                dim = self.entry and self.entry.dim, 
                 CenterContainer:new{
                     dimen = { w = target_w, h = target_h },
                     wimage,


### PR DESCRIPTION
修复无封面书籍的占位封面及列表视图下的书籍封面无选中效果的问题 #4 